### PR TITLE
Add unit tests for com.immomo.rhizobia.rhizobia_J.crypto.AESUtils

### DIFF
--- a/src/test/java/com/immomo/rhizobia/rhizobia_J/crypto/AESUtilsTest.java
+++ b/src/test/java/com/immomo/rhizobia/rhizobia_J/crypto/AESUtilsTest.java
@@ -1,0 +1,34 @@
+package com.immomo.rhizobia.rhizobia_J.crypto;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+public class AESUtilsTest {
+
+    private final byte[] foo = {26, 58, -78, 28, 39, -106, -66, -2,
+            -23, 12, 1, 78, -35, 17, -124, 26};
+    private final byte[] bar = {-106, -17, -12, -49, 0, 2, 55, 111,
+            -79, -63, -115, 100, -63, 99, -52, 121};
+
+    @Test
+    public void testEncrypt() throws Exception {
+        Assert.assertArrayEquals(foo,
+                AESUtils.getInstance("aesKey1", "secretKey1", null)
+                        .encrypt("foo"));
+
+        Assert.assertArrayEquals(bar,
+                AESUtils.getInstance("aesKey2", "secretKey2", null)
+                        .encrypt("bar"));
+    }
+
+    @Test
+    public void testDecrypt() throws Exception {
+        Assert.assertEquals("foo",
+                AESUtils.getInstance("aesKey1", "secretKey1", null)
+                        .decrypt(foo));
+
+        Assert.assertEquals("bar",
+                AESUtils.getInstance("aesKey2", "secretKey2", null)
+                        .decrypt(bar));
+    }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `com.immomo.rhizobia.rhizobia_J.crypto.AESUtils` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important.